### PR TITLE
Various fixes and proposals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@
 #            -e DISPLAY \
 #            -v /tmp/.X11-unix/:/tmp/.X11-unix \
 #            -v /dev/snd:/dev/snd \
-#            --privileged \
+#            -e PULSE_SERVER="unix:/pulse" \
+#            -v ${XDG_RUNTIME_DIR}/pulse/native:/pulse \
+#            --group-add $(getent group audio | cut -d: -f3) \
 #            local/alpine:firefox
 FROM alpine:edge
 MAINTAINER ivan@davidkov.eu
@@ -19,6 +21,8 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/reposi
        firefox-esr \
        libcanberra-gtk2 \
        pulseaudio \
+       mesa-gl \
+       dumb-init \
     && rm -fr /var/cache/apk/* \
     && adduser -D -u 1000 -g 1000 user
 
@@ -28,7 +32,7 @@ WORKDIR /home/user
 # switch to user
 USER user
 
-ENTRYPOINT ["/usr/bin/firefox", "--no-remote"]
+ENTRYPOINT ["/usr/bin/dumb-init", "/usr/bin/firefox", "--no-remote"]
 
 
 


### PR DESCRIPTION
* Use dumb-init instead of running firefox directly. Apparently this is better because the process with PID 1 gets special treatment that firefox might not deal with correctly. dumb-init runs firefox with PID > 1.
* Add package mesa-gl without which firefox won't run.
* Get sound working by connecting to pulseaudio on the host, this requires the user in alpine to belong to the group whose gid matches the audio group on the host system. The user does not have to belong to the audio group in alpine.

Tested and working on Ubuntu 14.04